### PR TITLE
build: DockerfileのCMDをdocker-compose.ymlに移動し、0.0.0.0で待受するよう修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,4 @@ COPY ./Gemfile ./Gemfile.lock ./
 RUN bundle install
 COPY . .
 ENTRYPOINT ["./bin/entrypoint.sh"]
-CMD ["./bin/dev", "-b", "0.0.0.0"]
 ENTRYPOINT ["./bin/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       DATABASE_PASSWORD: password
       RAILS_ENV: development
     # user: "1001:1002"
+    command: bash -lc "rm -f tmp/pids/server.pid && bin/rails s -b 0.0.0.0 -p 3000"
   chrome:
     image: seleniarm/standalone-chromium:latest
     ports:


### PR DESCRIPTION
## 概要
- Dockerfileに記載されていたCMD ["./bin/dev", "-b", "0.0.0.0"]を削除
- docker-compose.ymlのwebサービスにcommandを追加
- Pumaが0.0.0.0で待ち受けるように修正

## 目的
DockerfileにCMDを記載すると本番環境にも影響する可能性があるため、開発環境専用のdocker-compose.ymlに移動しました。

## 確認方法
1. `docker compose build`
2. `docker compose up`
3. http://localhost:3000 にアクセスし、Railsの画面が表示されることを確認